### PR TITLE
HXDZ op-code 

### DIFF
--- a/busch2090-mega-v4/busch2090-mega-v4.ino
+++ b/busch2090-mega-v4/busch2090-mega-v4.ino
@@ -3205,13 +3205,21 @@ void run() {
 
 	zero = num > 999;
 	carry = false;
+	
+	if (zero) {
+	
+	  reg[0xD] = 0;
+	  reg[0xE] = 0;
+	  reg[0xF] = 0;
 
-	num %= 1000;
-
-	reg[0xD] = num % 10;
-	reg[0xE] = ( num / 10 ) % 10;
-	reg[0xF] = ( num / 100 ) % 10;
-
+	} else {
+		
+	  reg[0xD] = num % 10;
+	  reg[0xE] = ( num / 10 ) % 10;
+	  reg[0xF] = ( num / 100 ) % 10;
+		
+	}
+	
 	break;
 
       case OP_DZHX :


### PR DESCRIPTION
Undocumented behaviour of the Microtronic 2090:
Overflow during HXDZ leads to 0 in all registers D, E, and F.