### PR TITLE
 HXDZ op-code

### DIFF
--- a/busch2090-pcb-midi/busch2090-pcb-midi.ino
+++ b/busch2090-pcb-midi/busch2090-pcb-midi.ino
@@ -2031,12 +2031,20 @@ void run()
         zero = num > 999;
         carry = false;
 
-        num %= 1000;
+        if (zero) {
+	
+	  reg[0xD] = 0;
+	  reg[0xE] = 0;
+	  reg[0xF] = 0;
 
-        reg[0xD] = num % 10;
-        reg[0xE] = (num / 10) % 10;
-        reg[0xF] = (num / 100) % 10;
-
+	} else {
+		
+	  reg[0xD] = num % 10;
+	  reg[0xE] = ( num / 10 ) % 10;
+	  reg[0xF] = ( num / 100 ) % 10;
+		
+	}
+	      
         break;
 
       case OP_DZHX:


### PR DESCRIPTION
Undocumented behaviour of the Microtronic 2090:
Overflow during HXDZ leads to 0 in all registers D, E, and F.